### PR TITLE
Add vitest setup and tests for user profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "concurrently \"vite\" \"node proxy-server.js\"",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.7",
@@ -40,6 +41,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/lib/__tests__/getOrCreateUserProfile.test.ts
+++ b/src/lib/__tests__/getOrCreateUserProfile.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getOrCreateUserProfile } from '../getOrCreateUserProfile';
+
+// Mock supabase client used in the module under test
+const supabaseMock = {
+  auth: { getUser: vi.fn() },
+  from: vi.fn(),
+};
+
+vi.mock('../supabase', () => ({ supabase: supabaseMock }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getOrCreateUserProfile', () => {
+  it('returns the existing profile', async () => {
+    const user = { id: '123' };
+    const profile = { id: '123', nombre: 'Existing' };
+
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user }, error: null });
+    supabaseMock.from.mockReturnValueOnce({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: profile, error: null }),
+    });
+
+    const result = await getOrCreateUserProfile();
+    expect(result).toEqual(profile);
+    expect(supabaseMock.from).toHaveBeenCalledWith('profiles');
+  });
+
+  it('inserts a profile when none exists', async () => {
+    const user = { id: '321' };
+    const newProfile = { id: '321', nombre: 'Nombre por defecto' };
+
+    supabaseMock.auth.getUser.mockResolvedValue({ data: { user }, error: null });
+
+    // First call: fetch attempt returning nothing
+    supabaseMock.from.mockImplementationOnce(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }),
+    }));
+
+    // Second call: insert new profile
+    const insertSelectMock = vi.fn().mockReturnThis();
+    const insertSingleMock = vi.fn().mockResolvedValue({ data: newProfile, error: null });
+    const insertMock = vi.fn(() => ({ select: insertSelectMock, single: insertSingleMock }));
+
+    supabaseMock.from.mockImplementationOnce(() => ({ insert: insertMock }));
+
+    const result = await getOrCreateUserProfile();
+    expect(result).toEqual(newProfile);
+    expect(insertMock).toHaveBeenCalledWith([{ id: user.id, nombre: 'Nombre por defecto' }]);
+    expect(supabaseMock.from).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+});


### PR DESCRIPTION
## Summary
- install Vitest testing framework
- configure Vitest to run in Node environment
- add unit tests for `getOrCreateUserProfile`
- expose `test` script in `package.json`

## Testing
- `npm test --silent` *(fails: vitest not found)*